### PR TITLE
Feature/signup modal

### DIFF
--- a/client/src/signup-modal.jsx
+++ b/client/src/signup-modal.jsx
@@ -7,9 +7,8 @@ const ModalSignup = styled.div`
     position: absolute;
     display: flex;
     justify-content: center;
-
     width: 100%;
-    height: 100%;
+    left: 0;
     top: 20%;
     z-index: 1;
 `;

--- a/client/src/signup-modal.jsx
+++ b/client/src/signup-modal.jsx
@@ -1,7 +1,7 @@
-import React from "react";
-import styled from "styled-components";
-
+import styled, { createGlobalStyle } from "styled-components";
+import React, { useState, useEffect } from 'react';
 import SignUpForm from "./signup-form.jsx";
+import { withRouter } from 'react-router-dom';
 
 const ModalSignup = styled.div`
     position: absolute;
@@ -28,17 +28,18 @@ const ModalSignupLayer = styled.div`
     z-index: -2;
     background-color: rgba(0, 0, 0, 0.4);
 `;
-const SignupModal = () => {
+const SignupModal = ({history}) => {
     return (
         <ModalSignup>
             <ModalSignupContent>
                 회원가입 폼
                 <SignUpForm />
             </ModalSignupContent>
-
-            <ModalSignupLayer />
+            <ModalSignupLayer onClick={() => {
+                history.goBack();
+            }} />
         </ModalSignup>
     );
 };
 
-export default SignupModal;
+export default withRouter(SignupModal);

--- a/client/src/signup-modal.jsx
+++ b/client/src/signup-modal.jsx
@@ -28,16 +28,25 @@ const ModalSignupLayer = styled.div`
     z-index: -2;
     background-color: rgba(0, 0, 0, 0.4);
 `;
-const SignupModal = ({history}) => {
+
+const CloseBtn = styled.button`
+    position: relative;
+    left: -33%;
+`;
+
+const closeModal = history => {
+    history.goBack();
+}
+
+const SignupModal = ({ history }) => {
     return (
         <ModalSignup>
             <ModalSignupContent>
+                <CloseBtn onClick={() => closeModal(history)}>X</CloseBtn>
                 회원가입 폼
                 <SignUpForm />
             </ModalSignupContent>
-            <ModalSignupLayer onClick={() => {
-                history.goBack();
-            }} />
+            <ModalSignupLayer onClick={() => closeModal(history)} />
         </ModalSignup>
     );
 };

--- a/server/package.json
+++ b/server/package.json
@@ -21,8 +21,12 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.17.1",
+    "jsonwebtoken": "^8.5.1",
     "morgan": "^1.10.0",
-    "mysql2": "^2.2.5"
+    "mysql2": "^2.2.5",
+    "passport": "^0.4.1",
+    "passport-jwt": "^4.0.0",
+    "passport-local": "^1.0.0"
   },
-  "proxy" : "http://localhost:3000"
+  "proxy": "http://localhost:3000"
 }


### PR DESCRIPTION
FEAT: 회원가입모달창 닫기버튼 추가
x버튼 클릭 시 이전화면으로 goBack()

STYLE: 회원가입 모달창 가운데로 이동
기존 height를 없애고 left를 0으로 주어 가운데 정렬

FEAT: withRouter, history 이용 회원가입 모달창 지우기
 회원가입 모달창 바깥부분 클릭 시 회원가입 모달 클릭 이전으로 이동