### PR TITLE
FEAT: 이슈 목록 추가 필터 레이아웃 구현

### DIFF
--- a/client/src/issues/issue-sort-dropdown.jsx
+++ b/client/src/issues/issue-sort-dropdown.jsx
@@ -1,9 +1,75 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 
+const StyledDropDownMenu = styled.div`
+    position: relative;
+    display: inline-block;
+    width: 150px;
+
+    &:hover {
+        cursor: pointer;
+    }
+`;
+
+const StyledMenuTitle = styled.div`
+    position: relative;
+    &:before {
+        content: "${(props) => props.title} 🔽";
+    }
+`;
+
+const StyledMenuContent = styled.div`
+    display: ${(props) => props.isVisible};
+    position: absolute;
+    width: 150px;
+    height: fit-content;
+    max-height: 300px;
+    z-index: 3;
+    background-color: white;
+    overflow: auto;
+    border: 1px solid rgba(97, 97, 97, 1);
+    border-radius: 5px;
+`;
+
+const StyledMenuUl = styled.ul`
+    list-style: none;
+    margin: 0;
+    padding: 4% 0%;
+`;
+
+const StyledMenuLi = styled.li`
+    border-bottom: 1px solid lightgray;
+    padding: 2% 0%;
+
+    &:hover {
+        background-color: #fafbfc;
+    }
+`;
+
 const DropDownMenu = (props) => {
-    //
-    return <div>{props.name}</div>;
+    const [menuVisibility, setMenuVisibility] = useState("none");
+
+    const onTitleClicked = (e) => {
+        e.preventDefault();
+        if (menuVisibility === "none") {
+            setMenuVisibility("block");
+        } else {
+            setMenuVisibility("none");
+        }
+    };
+
+    return (
+        <StyledDropDownMenu onClick={onTitleClicked}>
+            <StyledMenuTitle title={props.name} />
+            <StyledMenuContent isVisible={menuVisibility}>
+                <StyledMenuUl>
+                    {props.options.map(([key, option]) => (
+                        <StyledMenuLi key={key}>{option}</StyledMenuLi>
+                    ))}
+                </StyledMenuUl>
+            </StyledMenuContent>
+        </StyledDropDownMenu>
+    );
 };
 
 export default DropDownMenu;

--- a/client/src/issues/issues-list-section.jsx
+++ b/client/src/issues/issues-list-section.jsx
@@ -98,10 +98,42 @@ const IssuesListSection = () => {
                     </StyledListSortOpenClosedCheckBoxLabel>
                 </StyledListSortOpenClosedDiv>
                 <StyledListSortOptions>
-                    <DropdownMenu name={"Author"} />
-                    <DropdownMenu name={"Label"} />
-                    <DropdownMenu name={"Milestones"} />
-                    <DropdownMenu name={"Assignee"} />
+                    <DropdownMenu
+                        name={"Author"}
+                        options={[
+                            [1, "author1"],
+                            [2, "author2"],
+                            [3, "author3"],
+                            [4, "author4"],
+                        ]}
+                    />
+                    <DropdownMenu
+                        name={"Label"}
+                        options={[
+                            [1, "labe1"],
+                            [2, "labe2"],
+                            [3, "labe3"],
+                            [4, "labe4"],
+                        ]}
+                    />
+                    <DropdownMenu
+                        name={"Milestones"}
+                        options={[
+                            [1, "Milestone1"],
+                            [2, "Milestone2"],
+                            [3, "Milestone3"],
+                            [4, "Milestone4"],
+                        ]}
+                    />
+                    <DropdownMenu
+                        name={"Assignee"}
+                        options={[
+                            [1, "Assignee1"],
+                            [2, "Assignee2"],
+                            [3, "Assignee3"],
+                            [4, "Assignee4"],
+                        ]}
+                    />
                 </StyledListSortOptions>
             </StyledListSortMenu>
             <StyledSortedList>


### PR DESCRIPTION
## FEAT: 이슈 목록 추가 필터 레이아웃 구현 e362de3

- 추가 필터 클릭시 dropdown 메뉴
- 한번 더 클릭시 메뉴 hidden

### TODO

- dropdown 메뉴 component 별도 분리 후 재사용
  - 9a33d2f2a3eda0c6573aaa88f048b115ebbe48a0 이전 dropdown과 병합
- window 클릭 시 menu close
- fetching api