### PR TITLE
FEAT: filter text remover 추가

### DIFF
--- a/client/src/issues/filter-text-remover.jsx
+++ b/client/src/issues/filter-text-remover.jsx
@@ -1,0 +1,70 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+
+const StyledRemoverDiv = styled.div`
+    display: ${(props) => (props.isRemoverVisible ? "flex" : "none")};
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    width: 600px;
+    margin: 10px;
+`;
+
+const StyledRemoverIcon = styled.svg.attrs({
+    version: "1.1",
+    width: "15px",
+    height: "15px",
+    id: "Capa_1",
+    xmlns: "http://www.w3.org/2000/svg",
+    viewBox: "0 0 512 512",
+})`
+    margin-right: 10px;
+`;
+
+const StyledRemoverMessage = styled.p`
+    margin: 0;
+`;
+
+// setVisible={setIsFilterTextRemoverVisible}
+const FilterTextRemover = (props) => {
+    const isVisible = props.isVisible;
+    const setVisible = props.setVisible;
+    const setTextInput = props.setTextInput;
+
+    const onMessageClick = () => {
+        setVisible(false);
+        setTextInput("");
+    };
+
+    return (
+        <StyledRemoverDiv isRemoverVisible={isVisible} onClick={onMessageClick}>
+            <StyledRemoverIcon>
+                <g>
+                    <g>
+                        <path
+                            d="M256,0C114.508,0,0,114.497,0,256c0,141.493,114.497,256,256,256c141.492,0,256-114.497,256-256
+			C512,114.507,397.503,0,256,0z M256,472c-119.384,0-216-96.607-216-216c0-119.385,96.607-216,216-216
+			c119.384,0,216,96.607,216,216C472,375.385,375.393,472,256,472z"
+                        />
+                    </g>
+                </g>
+                <g>
+                    <g>
+                        <path
+                            d="M343.586,315.302L284.284,256l59.302-59.302c7.81-7.81,7.811-20.473,0.001-28.284c-7.812-7.811-20.475-7.81-28.284,0
+			L256,227.716l-59.303-59.302c-7.809-7.811-20.474-7.811-28.284,0c-7.81,7.811-7.81,20.474,0.001,28.284L227.716,256
+			l-59.302,59.302c-7.811,7.811-7.812,20.474-0.001,28.284c7.813,7.812,20.476,7.809,28.284,0L256,284.284l59.303,59.302
+			c7.808,7.81,20.473,7.811,28.284,0C351.398,335.775,351.397,323.112,343.586,315.302z"
+                        />
+                    </g>
+                </g>
+            </StyledRemoverIcon>
+
+            <StyledRemoverMessage>
+                Clear current search query and filters
+            </StyledRemoverMessage>
+        </StyledRemoverDiv>
+    );
+};
+
+export default FilterTextRemover;

--- a/client/src/issues/filter.jsx
+++ b/client/src/issues/filter.jsx
@@ -86,6 +86,7 @@ const Filter = (props) => {
     const [modalVisible, setModalVisible] = useState(false);
     const setTextInput = props.setTextInput;
     const getTextInput = props.getTextInput;
+    const setFilterTextRemoverVisibility = props.setFilterTextRemoverVisibility;
 
     const onFilterSelectedChange = (e) => {
         if (e.target) {
@@ -101,6 +102,7 @@ const Filter = (props) => {
         } = e;
 
         setTextInput(value);
+        setFilterTextRemoverVisibility(true);
     };
 
     const onFilterKeyPress = (e) => {

--- a/client/src/issues/issue-item-banner.jsx
+++ b/client/src/issues/issue-item-banner.jsx
@@ -43,31 +43,20 @@ const StyledBannerInfo = styled.p`
 let count = 0;
 let total;
 
-// color: "#FF0000"
-// content: "bug"
-// issueId: 1
-// issueTitle: "목록 보기 구현"
-// labelId: 2
-// milestoneId: 1
-// milestoneTitle: "스프린트2"
-// status: 1
-// userId: "123123"
-// writingTime: "2020-10-28T15:00:00.000Z"
 const IssueTitle = (props) => {
     const [checked, setChecked] = useState(false);
     const openOrClosed = props.status === 1 ? "opened" : "closed";
 
     const timeNow = Date.now();
     const updatedTimeBefore = new Date(
-        timeNow - new Date(props.writingTime),
+        timeNow - new Date(props.writingTime)
     ).getDate();
 
     useEffect(() => {
         if (props.checked) {
             setChecked(props.checked);
             count = props.count;
-        }
-        else {
+        } else {
             if (count == props.count || count == 0) {
                 setChecked(props.checked);
                 count = 0;
@@ -77,7 +66,7 @@ const IssueTitle = (props) => {
 
     const checkedFunc = () => {
         return checked;
-    }
+    };
 
     const setCheckFunc = () => {
         if (checked) {
@@ -85,8 +74,7 @@ const IssueTitle = (props) => {
             props.excludeIssueFunc(props.issueId);
             props.func2(false);
             count--;
-        }
-        else {
+        } else {
             count++;
             props.addIssueFunc(props.issueId);
             if (count == props.count) {
@@ -95,12 +83,15 @@ const IssueTitle = (props) => {
         }
         props.selectedFunc(count);
         setChecked(!checked);
-    }
+    };
 
     return (
         <StyledBannersListDiv>
             <StyledBannerCheckBoxDiv>
-                <StyledBannerCheckBoxInput checked={checkedFunc()} onChange={setCheckFunc} />
+                <StyledBannerCheckBoxInput
+                    checked={checkedFunc()}
+                    onChange={setCheckFunc}
+                />
             </StyledBannerCheckBoxDiv>
 
             <StyledBannerOpenClosedDiv>
@@ -109,6 +100,7 @@ const IssueTitle = (props) => {
 
             <StyledBannerTextDiv>
                 <StyledBannerTitle>{props.issueTitle}</StyledBannerTitle>
+                {console.log(props.labelInfo)}
                 <StyledBannerInfo>
                     #{props.issueId} by {props.userId} was {openOrClosed}{" "}
                     {updatedTimeBefore} days ago

--- a/client/src/issues/issues-list-section.jsx
+++ b/client/src/issues/issues-list-section.jsx
@@ -184,8 +184,6 @@ const IssuesListSection = (props) => {
         }
     });
 
-    console.log(filterOptions);
-
     const filteredIssueData = issueData
         .filter((ele) => ele.status === openClosedRadio)
         .filter((ele) =>

--- a/client/src/issues/list.jsx
+++ b/client/src/issues/list.jsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import Filter from "./filter.jsx";
 import HeaderButtons from "./header-buttons.jsx";
 import IssuesList from "./issues-list-section.jsx";
+import FilterTextRemover from "./filter-text-remover.jsx";
 
 const StyledListDiv = styled.div`
     display: flex;
@@ -23,7 +24,11 @@ const StyledListHeader = styled.div`
 
 const IssueList = () => {
     const [textInput, setTextInput] = useState("is:open");
-    const [isOpen, setIsOpen] = useState(true);
+    const [isOpen, setIsOpen] = useState(false);
+    const [
+        isFilterTextRemoverVisible,
+        setIsFilterTextRemoverVisible,
+    ] = useState(false);
 
     const getTextInput = () => textInput;
     const addOptionToTextInput = (option) => {
@@ -46,16 +51,23 @@ const IssueList = () => {
     };
 
     return (
-        // TODO
         <StyledListDiv>
             <StyledListHeader>
                 <Filter
                     setIsOpen={setIsOpen}
                     setTextInput={setTextInput}
                     getTextInput={getTextInput}
+                    setFilterTextRemoverVisibility={
+                        setIsFilterTextRemoverVisible
+                    }
                 />
                 <HeaderButtons />
             </StyledListHeader>
+            <FilterTextRemover
+                isVisible={isFilterTextRemoverVisible}
+                setVisible={setIsFilterTextRemoverVisible}
+                setTextInput={setTextInput}
+            />
             <IssuesList
                 filterOptions={textInput}
                 addOptionToTextInput={addOptionToTextInput}


### PR DESCRIPTION
## FEAT: filter text remover 추가 dbb283a

- filter text 입력시 활성화; `display: flex`
- onClick 시 `display: none`
- 초기 state === false

## STYLE: linted by Prettier-ESLint, remove `log` bac5a9f

## Merge branch 'Dev' of https://github.com/boostcamp-2020/IssueTracker-30… 73000e1
