### PR TITLE
FEAT: issue banner title 및 author에 `onClick` 추가

### DIFF
--- a/client/src/issues/issue-item-banner.jsx
+++ b/client/src/issues/issue-item-banner.jsx
@@ -43,6 +43,11 @@ const StyledBannerTitle = styled.p`
     font-weight: 700;
     font-size: 1em;
     margin: 0;
+
+    &:hover {
+        cursor: pointer;
+        color: #3949ab;
+    }
 `;
 
 const StyledBannerLabel = styled.div`
@@ -62,11 +67,21 @@ const StyledBannerLabel = styled.div`
     }
 `;
 
-const StyledBannerInfo = styled.p`
+const StyledBannerInfo = styled.div`
+    display: flex;
+    flex-direction: row;
     font-family: "Noto Sans KR", sans-serif;
     font-weight: 400;
     font-size: 0.7em;
     margin: 0;
+`;
+
+const StyledBannerAuthor = styled.div`
+    margin: 0 2px;
+    &:hover {
+        cursor: pointer;
+        color: #3949ab;
+    }
 `;
 
 const StyledAssigneeDiv = styled.div`
@@ -147,7 +162,14 @@ const IssueTitle = (props) => {
     });
 
     const onIssueBannerClick = (e) => {
-        //
+        e.preventDefault();
+        // TODO: 상세페이지 api?
+        window.location.href = `/issue/detail/${props.issueId}`;
+    };
+
+    const onAuthorClick = () => {
+        // TODO
+        props.addOptionToTextInput(`author:${props.userId}`);
     };
 
     return (
@@ -165,10 +187,7 @@ const IssueTitle = (props) => {
 
             <StyledBannerTextDiv>
                 <StyledBannerInnerDiv>
-                    <StyledBannerTitle
-                        uri={props.issueId}
-                        onClick={onIssueBannerClick}
-                    >
+                    <StyledBannerTitle onClick={onIssueBannerClick}>
                         {props.issueTitle}
                     </StyledBannerTitle>
                     {labelData.map((element) => (
@@ -190,7 +209,10 @@ const IssueTitle = (props) => {
                 </StyledBannerInnerDiv>
                 <StyledBannerInfo>
                     #{props.issueId} {openOrClosed} {updatedTimeBefore} days ago
-                    by {props.userId}
+                    by{"  "}
+                    <StyledBannerAuthor onClick={onAuthorClick}>
+                        {props.userId}
+                    </StyledBannerAuthor>
                 </StyledBannerInfo>
             </StyledBannerTextDiv>
         </StyledBannersListDiv>

--- a/client/src/issues/issues-list-section.jsx
+++ b/client/src/issues/issues-list-section.jsx
@@ -367,6 +367,7 @@ const IssuesListSection = (props) => {
                                 color: labelColor,
                                 content: labelContent,
                             }}
+                            addOptionToTextInput={props.addOptionToTextInput}
                         />
                     )
                 )}


### PR DESCRIPTION
- title 클릭시 상세 페이지로 이동
  - API 연결 필요
- author 클릭시 작성자명으로 검색