### PR TITLE
FEAT&FIX: labels 페이지 기본 레이아웃, footer 위치 하단으로 고정

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,11 +1,18 @@
 import React, { useState, useEffect } from "react";
 import { Switch, Route, BrowserRouter as Router } from "react-router-dom";
 import axios from "axios";
+import styled from "styled-components";
 
 import NavBar from "./components/nav-bar.jsx";
 import MainSection from "./main-section.jsx";
 import Footer from "./components/footer.jsx";
 import DetailIssue from "./detailIssue/detail-issue.jsx";
+import Labels from "./labels/labels-list.jsx";
+
+const StyledRouter = styled(Router)`
+    display: flex;
+    flex-direction: column;
+`;
 
 const loginCheck = async () => {
     if (document.cookie.split("=")[0] === "user") {
@@ -29,10 +36,6 @@ const loginCheck = async () => {
 const App = () => {
     const [mode, setMode] = useState("login");
 
-    const changeMode = (props) => {
-        alert(props);
-    }
-
     useEffect(() => {
         loginCheck().then(async (res) => {
             if (res === "main") {
@@ -43,7 +46,7 @@ const App = () => {
                 }).then((issueData) => {
                     localStorage.setItem(
                         "issueData",
-                        JSON.stringify(issueData.data),
+                        JSON.stringify(issueData.data)
                     );
                 });
 
@@ -54,7 +57,7 @@ const App = () => {
                 }).then((users) => {
                     localStorage.setItem(
                         "usersData",
-                        JSON.stringify(users.data),
+                        JSON.stringify(users.data)
                     );
                 });
 
@@ -65,7 +68,7 @@ const App = () => {
                 }).then((labels) => {
                     localStorage.setItem(
                         "labelsData",
-                        JSON.stringify(labels.data),
+                        JSON.stringify(labels.data)
                     );
                 });
 
@@ -76,7 +79,7 @@ const App = () => {
                 }).then((milestones) => {
                     localStorage.setItem(
                         "milestonesData",
-                        JSON.stringify(milestones.data),
+                        JSON.stringify(milestones.data)
                     );
                 });
                 setMode(res);
@@ -85,21 +88,20 @@ const App = () => {
     }, []);
 
     return (
-        <>
-            <Router>
-                <NavBar mode={mode} />
-                <Switch>
-                    <Route path="/new">
-                        <MainSection mode="newIssue" />
-                    </Route>
-                    <Route path="/detail/:issueId" component={DetailIssue} />
-                    <Route path="/">
-                        <MainSection mode={mode} />
-                    </Route>
-                </Switch>
-                <Footer />
-            </Router>
-        </>
+        <StyledRouter>
+            <NavBar mode={mode} />
+            <Switch>
+                <Route path="/new">
+                    <MainSection mode="newIssue" />
+                </Route>
+                <Route path="/detail/:issueId" component={DetailIssue} />
+                <Route path="/labels" component={Labels} />
+                <Route path="/">
+                    <MainSection mode={mode} />
+                </Route>
+            </Switch>
+            <Footer />
+        </StyledRouter>
     );
 };
 

--- a/client/src/components/footer.jsx
+++ b/client/src/components/footer.jsx
@@ -2,15 +2,15 @@ import React from "react";
 import styled from "styled-components";
 
 const StyledFooter = styled.div`
-  width: 100%;
-  height: 10vh;
-  background-color: #24292f;
-`
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+    height: 10vh;
+    background-color: #24292f;
+`;
 
 const Footer = () => {
-    return (
-        <StyledFooter/>
-    );
+    return <StyledFooter />;
 };
 
 export default Footer;

--- a/client/src/labels/labels-list.jsx
+++ b/client/src/labels/labels-list.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import styled from "styled-components";
+
+const StyledLabels = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
+const StyledHeader = styled.header`
+    display: flex;
+`;
+
+const StyledHeaderRadio = styled.input.attrs({
+    type: "radio",
+})``;
+
+const LabelsList = () => {
+    return (
+        <StyledLabels>
+            <StyledHeader>
+                <StyledHeaderRadio />
+            </StyledHeader>
+        </StyledLabels>
+    );
+};
+
+export default LabelsList;


### PR DESCRIPTION
## FIX: footer 위치 하단으로 고정 ffca274
- `position: fixed` 추가

## FEAT: labels 페이지 기본 레이아웃 4d9b93b

## Merge branch 'Dev' of https://github.com/boostcamp-2020/IssueTracker-30 702fd12