### PR TITLE
FIX: labels 페이지 초기 로딩시 데이터 안보이는 에러, labels 목록 길어질 경우 하단 안보이는 에러 수정

### DIFF
--- a/client/src/components/search-list.jsx
+++ b/client/src/components/search-list.jsx
@@ -19,8 +19,6 @@ const StyledList = styled.div`
     font-size: 12px;
 `;
 
-const labelsData = JSON.parse(localStorage.getItem("labelsData"));
-
 const compareDataWithFilter = (dataText, filterTextLine) => {
     if (filterTextLine === "") return true;
     const splittedText = filterTextLine.split(" ");
@@ -32,6 +30,7 @@ const compareDataWithFilter = (dataText, filterTextLine) => {
 };
 
 const SearchList = ({ getRandomColor, filterText }) => {
+    const labelsData = JSON.parse(localStorage.getItem("labelsData"));
     const filteredData = labelsData?.filter(
         (ele) =>
             compareDataWithFilter(ele.content, filterText) ||

--- a/client/src/labels/label-banner.jsx
+++ b/client/src/labels/label-banner.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import axios from "axios";
@@ -8,12 +8,12 @@ import LabelEditor from "./label-editor.jsx";
 const StyledLabelBanner = styled.div`
     display: flex;
     flex-direction: column;
-    justify-content: space-around;
+    justify-content: flex-start;
     align-items: center;
 
-    width: 900px;
-    min-height: 50px;
-    padding: 10px 0;
+    width: 100%;
+    height: max-content;
+    padding: 5px;
     box-shadow: 0 1px 1px -1px rgb(36, 41, 46);
 
     &:hover {

--- a/client/src/labels/list-search-result.jsx
+++ b/client/src/labels/list-search-result.jsx
@@ -19,8 +19,11 @@ const StyledLablesList = styled.div`
     display: flex;
     flex-direction: column;
 
-    width: 900px;
+    width: 100%;
     height: 100%;
+    max-height: 63vh;
+    overflow-y: auto;
+    overflow-x: hidden;
 `;
 
 const ListSearchResult = ({ labelsData, numOfLabel, getRandomColor }) => {


### PR DESCRIPTION
# FIX

##  labels 페이지 초기 로딩시 데이터 안보이는 에러 수정 56fbe28

- `getItems` 함수 실행 위치 변경
  - component render 함수 밖에서 안으로 이동

## labels 목록 길어질 경우 하단 안보이는 에러 수정 0d2d815

- overflow 설정 추가
- banner 사이즈 및 위치 수정